### PR TITLE
Now buildable on LLVM 11

### DIFF
--- a/dataflow/Dataflow.h
+++ b/dataflow/Dataflow.h
@@ -2,7 +2,7 @@
 #include "llvm/IR/Instructions.h"
 #include "llvm/IR/Function.h"
 #include "llvm/IR/InstIterator.h"
-#include "llvm/Analysis/CFG.h"
+#include "llvm/IR/CFG.h"
 
 #include <vector>
 #include <set>


### PR DESCRIPTION
Since they changed the position of CFG.h in the latest versions of LLVM, it should be a good idea to update it on this project as well.